### PR TITLE
feat(ai): Implement Community Ignition Toolkit

### DIFF
--- a/apps/ai-engine/go.mod
+++ b/apps/ai-engine/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/google/uuid v1.6.0
+	github.com/joho/godotenv v1.3.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tmc/langchaingo v0.1.13

--- a/apps/ai-engine/go.sum
+++ b/apps/ai-engine/go.sum
@@ -111,6 +111,7 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/apps/ai-engine/internal/api/router.go
+++ b/apps/ai-engine/internal/api/router.go
@@ -5,17 +5,19 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/qolzam/telar/apps/ai-engine/internal/config"
+	"github.com/qolzam/telar/apps/ai-engine/internal/generator"
 	"github.com/qolzam/telar/apps/ai-engine/internal/knowledge"
 )
 
 // Router creates and configures the Fiber application with middleware and routes
-func Router(knowledgeService *knowledge.Service) *fiber.App {
-	handler := NewHandler(knowledgeService)
-	
+func Router(knowledgeService *knowledge.Service, generatorService *generator.Service, config *config.Config) *fiber.App {
+	handler := NewHandler(knowledgeService, generatorService, config)
+
 	app := fiber.New(fiber.Config{
 		AppName: "AI Engine v1.0.0",
 	})
-	
+
 	app.Use(logger.New())
 	app.Use(recover.New())
 	app.Use(cors.New(cors.Config{
@@ -23,19 +25,22 @@ func Router(knowledgeService *knowledge.Service) *fiber.App {
 		AllowMethods: "GET,POST,PUT,DELETE,OPTIONS",
 		AllowHeaders: "Content-Type,Authorization",
 	}))
-	
+
 	// API routes
 	app.Get("/health", handler.Health)
 	app.Get("/status", handler.GetStatus)
-	
+
 	// Serve static files from public directory
 	app.Static("/", "./public", fiber.Static{
 		Index: "index.html",
 	})
-	
+
 	v1 := app.Group("/api/v1")
 	v1.Post("/ingest", handler.Ingest)
 	v1.Post("/query", handler.Query)
-	
+	v1.Post("/generate/conversation-starters", handler.GenerateConversationStarters)
+	v1.Get("/concurrent-status", handler.GetConcurrentStatus)
+	v1.Get("/model-config", handler.GetModelConfig)
+
 	return app
 }

--- a/apps/ai-engine/internal/config/config.go
+++ b/apps/ai-engine/internal/config/config.go
@@ -35,6 +35,7 @@ type LLMConfig struct {
 	OllamaBaseURL      string `json:"ollama_base_url,omitempty"`
 	EmbeddingModel     string `json:"embedding_model,omitempty"`
 	CompletionModel    string `json:"completion_model,omitempty"`
+	MaxConcurrent      int    `json:"max_concurrent,omitempty"`
 }
 
 // WeaviateConfig contains vector database settings
@@ -58,6 +59,7 @@ func Load() (*Config, error) {
 	viper.SetDefault("GROQ_MODEL", "llama3-8b-8192")
 	viper.SetDefault("OPENAI_BASE_URL", "https://api.openai.com/v1")
 	viper.SetDefault("OPENAI_MODEL", "gpt-3.5-turbo")
+	viper.SetDefault("MAX_CONCURRENT", "2")
 	viper.SetDefault("WEAVIATE_URL", "http://localhost:8080")
 
 	viper.AutomaticEnv()
@@ -81,6 +83,7 @@ func Load() (*Config, error) {
 			OllamaBaseURL:      viper.GetString("OLLAMA_BASE_URL"),
 			EmbeddingModel:     viper.GetString("EMBEDDING_MODEL"),
 			CompletionModel:    viper.GetString("COMPLETION_MODEL"),
+			MaxConcurrent:      viper.GetInt("MAX_CONCURRENT"),
 		},
 		Weaviate: WeaviateConfig{
 			URL:    viper.GetString("WEAVIATE_URL"),

--- a/apps/ai-engine/internal/generator/service.go
+++ b/apps/ai-engine/internal/generator/service.go
@@ -1,0 +1,159 @@
+package generator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/prompts"
+)
+
+// Service handles generative AI tasks that don't require RAG.
+type Service struct {
+	compClient     llms.Model
+	semaphore      chan struct{} 
+	maxConcurrent  int
+	requestTimeout time.Duration
+}
+
+// Request represents a queued generation request
+type Request struct {
+	Topic  string
+	Style  string
+	Result chan Result
+}
+
+// Result represents the result of a generation request
+type Result struct {
+	Starters []string
+	Error    error
+}
+
+// Queue manages pending requests
+type Queue struct {
+	requests chan Request
+	mu       sync.RWMutex
+	closed   bool
+}
+
+// NewService creates a new generator service with concurrent request limiting.
+func NewService(compClient llms.Model, maxConcurrent int) *Service {
+	if maxConcurrent <= 0 {
+		maxConcurrent = 2 
+	}
+	return &Service{
+		compClient:     compClient,
+		semaphore:      make(chan struct{}, maxConcurrent),
+		maxConcurrent:  maxConcurrent,
+		requestTimeout: 60 * time.Second, 
+	}
+}
+
+// NewQueue creates a new request queue.
+func NewQueue(bufferSize int) *Queue {
+	return &Queue{
+		requests: make(chan Request, bufferSize),
+	}
+}
+
+// Enqueue adds a request to the queue.
+func (q *Queue) Enqueue(req Request) error {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	
+	if q.closed {
+		return fmt.Errorf("queue is closed")
+	}
+	
+	select {
+	case q.requests <- req:
+		return nil
+	default:
+		return fmt.Errorf("queue is full, please try again later")
+	}
+}
+
+// Close closes the queue.
+func (q *Queue) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	
+	if !q.closed {
+		close(q.requests)
+		q.closed = true
+	}
+}
+
+// GenerateConversationStarters creates engaging prompts for a community with concurrent request limiting.
+func (s *Service) GenerateConversationStarters(ctx context.Context, topic, style string) ([]string, error) {
+	// Try to acquire semaphore with timeout
+	select {
+	case s.semaphore <- struct{}{}:
+		defer func() { <-s.semaphore }() 
+	case <-time.After(5 * time.Second):
+		return nil, fmt.Errorf("server is currently processing too many requests, please try again in a moment")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	genCtx, cancel := context.WithTimeout(ctx, s.requestTimeout)
+	defer cancel()
+
+	return s.generateConversationStartersInternal(genCtx, topic, style)
+}
+
+// generateConversationStartersInternal performs the actual generation work.
+func (s *Service) generateConversationStartersInternal(ctx context.Context, topic, style string) ([]string, error) {
+	// A robust, instruction-following prompt template.
+	prompt := prompts.NewPromptTemplate(
+		`You are an expert community manager. Your task is to generate three high-quality, open-ended discussion prompts for a community of '{{.topic}}'.
+		The desired tone is '{{.style}}'.
+		You must follow these rules:
+		1. Generate exactly three distinct prompts.
+		2. The prompts must be engaging and encourage conversation.
+		3. Your response MUST be ONLY a raw JSON array of strings, with no other text, comments, or explanations.
+		Example response: ["What is your favorite new feature in Go 1.23?", "How do you handle work-life balance as a developer?", "If you could refactor any public Go repository, which one would it be and why?"]`,
+		[]string{"topic", "style"},
+	)
+
+	// Use LangChainGo to format the prompt, just like in the KnowledgeService.
+	formattedPrompt, err := prompt.Format(map[string]any{
+		"topic": topic,
+		"style": style,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to format prompt: %w", err)
+	}
+
+	// Call your existing, provider-agnostic completion client.
+	response, err := llms.GenerateFromSinglePrompt(ctx, s.compClient, formattedPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("llm client failed to generate starters: %w", err)
+	}
+
+	// Parse the clean JSON response from the LLM.
+	var starters []string
+	if err := json.Unmarshal([]byte(response), &starters); err != nil {
+		// This is a critical fallback for when the LLM doesn't follow instructions perfectly.
+		return nil, fmt.Errorf("failed to parse LLM JSON response: %w. Raw response: %s", err, response)
+	}
+
+	return starters, nil
+}
+
+// GetConcurrentStatus returns the current status of concurrent request handling.
+func (s *Service) GetConcurrentStatus() map[string]interface{} {
+	activeRequests := len(s.semaphore)
+	availableSlots := s.maxConcurrent - activeRequests
+	
+	return map[string]interface{}{
+		"max_concurrent":    s.maxConcurrent,
+		"active_requests":   activeRequests,
+		"available_slots":   availableSlots,
+		"request_timeout":   s.requestTimeout.String(),
+		"can_accept_request": availableSlots > 0,
+	}
+}

--- a/apps/ai-engine/internal/knowledge/service.go
+++ b/apps/ai-engine/internal/knowledge/service.go
@@ -14,9 +14,9 @@ import (
 
 // Service provides knowledge management and retrieval functionality
 type Service struct {
-	embedClient  llm.EmbeddingClient
-	compClient   llms.Model
-	vectorClient *weaviate.Client
+	embedClient    llm.EmbeddingClient
+	compClient     llms.Model
+	vectorClient   *weaviate.Client
 	embeddingModel string
 }
 
@@ -44,6 +44,21 @@ type DocumentRequest struct {
 	ID       string            `json:"id"`
 	Text     string            `json:"text"`
 	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// GenerationRequest represents a request for generating conversation starters
+type GenerationRequest struct {
+	Topic string `json:"topic"`
+	Style string `json:"style"`
+	Count int    `json:"count"`
+}
+
+// GenerationResponse represents the result of conversation starter generation
+type GenerationResponse struct {
+	Starters         []string `json:"starters"`
+	Model            string   `json:"model"`
+	PromptTokens     int      `json:"prompt_tokens,omitempty"`
+	CompletionTokens int      `json:"completion_tokens,omitempty"`
 }
 
 // NewService creates a new knowledge service instance
@@ -101,7 +116,7 @@ func (s *Service) QueryKnowledge(ctx context.Context, req *QueryRequest) (*Query
 
 	var contextBuilder strings.Builder
 	var avgRelevance float32
-	
+
 	for i, result := range searchResults {
 		contextBuilder.WriteString(fmt.Sprintf("Source %d: %s\n", i+1, result.Document.Text))
 		avgRelevance += result.Score
@@ -133,6 +148,203 @@ func (s *Service) QueryKnowledge(ctx context.Context, req *QueryRequest) (*Query
 
 	log.Printf("Successfully generated answer for query: %s", req.Query)
 	return response, nil
+}
+
+// GenerateConversationStarters creates engaging conversation starters for community topics
+func (s *Service) GenerateConversationStarters(ctx context.Context, req *GenerationRequest) (*GenerationResponse, error) {
+	log.Printf("Generating conversation starters for topic: %s", req.Topic)
+
+	prompt := prompts.NewPromptTemplate(`Create {{.count}} conversation starters for: "{{.topic}}"
+
+Style: {{.style_guide}}
+
+MANDATORY REQUIREMENT: Create DIFFERENT formats. DO NOT make all questions!
+
+STRICT FORMAT DISTRIBUTION:
+- Only 1 question maximum
+- Use statements, tips, challenges, scenarios, opinions
+
+REQUIRED FORMATS (copy these exactly):
+FORMAT 1 - STATEMENT: "The biggest mistake in [topic] is..."
+FORMAT 2 - TIP: "Pro tip: [specific advice]"  
+FORMAT 3 - CHALLENGE: "Try this [topic] challenge: [specific task]"
+FORMAT 4 - OPINION: "Unpopular opinion: [controversial take]"
+FORMAT 5 - SCENARIO: "Imagine you had to [specific scenario]..."
+FORMAT 6 - SHARING: "Share your experience with [specific situation]"
+
+EXAMPLES (follow these patterns):
+1. The biggest fitness myth is that you need 2 hours at the gym daily
+2. Pro tip: Track your protein intake for one week and you'll be amazed at the gaps
+3. Try this challenge: Do 10 push-ups every time you check social media today  
+4. Unpopular opinion: Rest days are more important than workout days
+5. Imagine you could only do bodyweight exercises for the next month - what's your plan?
+
+Create {{.count}} starters using THESE EXACT FORMATS:`,
+		[]string{"topic", "count", "style_guide"},
+	)
+
+	var styleGuide string
+	switch strings.ToLower(req.Style) {
+	case "professional":
+		styleGuide = "Keep the tone professional and industry-focused. Emphasize expertise, best practices, and career development."
+	case "casual":
+		styleGuide = "Use a friendly, relaxed tone. Make it feel like chatting with friends. Include personal experiences and fun elements."
+	case "educational":
+		styleGuide = "Focus on learning and knowledge sharing. Include questions that help people discover new concepts and deepen understanding."
+	case "creative":
+		styleGuide = "Encourage imaginative thinking and creative solutions. Include 'what if' scenarios and innovative approaches."
+	default: // "engaging" or any other style
+		styleGuide = "Balance professionalism with approachability. Make it exciting and thought-provoking while remaining inclusive and welcoming."
+	}
+
+	formattedPrompt, err := prompt.Format(map[string]any{
+		"topic":       req.Topic,
+		"count":       req.Count,
+		"style_guide": styleGuide,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to format generation prompt: %w", err)
+	}
+
+	completion, err := s.generateCompletion(ctx, formattedPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate completion: %w", err)
+	}
+
+	starters := s.parseConversationStarters(completion)
+
+	starters = s.diversifyStarterFormats(starters, req.Topic, req.Style)
+
+	if len(starters) == 0 {
+		return nil, fmt.Errorf("failed to generate any conversation starters from completion")
+	}
+
+	response := &GenerationResponse{
+		Starters: starters,
+		Model:    "completion-model", 
+	}
+
+	log.Printf("Successfully generated %d conversation starters for topic: %s", len(starters), req.Topic)
+	return response, nil
+}
+
+// parseConversationStarters extracts individual conversation starters from LLM completion
+func (s *Service) parseConversationStarters(completion string) []string {
+	var starters []string
+	lines := strings.Split(completion, "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if strings.Contains(line, ".") && len(line) > 3 {
+			
+			parts := strings.SplitN(line, ".", 2)
+			if len(parts) == 2 {
+				firstPart := strings.TrimSpace(parts[0])
+				if len(firstPart) <= 3 && strings.ContainsAny(firstPart, "0123456789") {
+					line = strings.TrimSpace(parts[1])
+				}
+			}
+		}
+
+		line = strings.Trim(line, "\"'-")
+		line = strings.TrimSpace(line)
+
+		lowerLine := strings.ToLower(line)
+		isMetaText := strings.HasPrefix(lowerLine, "here are") ||
+			strings.HasPrefix(lowerLine, "here is") ||
+			strings.HasPrefix(lowerLine, "these are") ||
+			strings.HasPrefix(lowerLine, "this is") ||
+			strings.Contains(lowerLine, "conversation starter") ||
+			strings.Contains(lowerLine, "discussion prompt") ||
+			strings.Contains(lowerLine, "community:") ||
+			strings.Contains(lowerLine, "for the") && strings.Contains(lowerLine, "community") ||
+			strings.HasPrefix(lowerLine, "i hope") ||
+			strings.HasPrefix(lowerLine, "these questions") ||
+			strings.HasPrefix(lowerLine, "these prompts") ||
+			strings.Contains(lowerLine, "encourages sharing") ||
+			strings.Contains(lowerLine, "accessible to both beginners")
+
+		if len(line) > 20 && !isMetaText {
+			starters = append(starters, line)
+		}
+	}
+
+	return starters
+}
+
+// diversifyStarterFormats transforms some questions into other formats for variety
+func (s *Service) diversifyStarterFormats(starters []string, topic, style string) []string {
+	if len(starters) < 2 {
+		return starters
+	}
+
+	diversified := make([]string, len(starters))
+	copy(diversified, starters)
+
+	for i := 1; i < len(diversified) && i < 4; i += 2 {
+		starter := diversified[i]
+		lowerStarter := strings.ToLower(starter)
+
+		if strings.HasPrefix(lowerStarter, "what") || strings.HasPrefix(lowerStarter, "how") ||
+			strings.HasPrefix(lowerStarter, "why") || strings.HasPrefix(lowerStarter, "when") ||
+			strings.HasPrefix(lowerStarter, "where") || strings.HasSuffix(starter, "?") {
+
+			switch i {
+			case 1:
+				diversified[i] = s.transformToTip(starter, topic)
+			case 3:
+				diversified[i] = s.transformToStatement(starter, topic)
+			}
+		}
+	}
+
+	return diversified
+}
+
+// transformToTip converts a question to a tip format
+func (s *Service) transformToTip(question, topic string) string {
+	cleaned := strings.TrimSuffix(question, "?")
+	cleaned = strings.TrimSpace(cleaned)
+
+	lowerQ := strings.ToLower(cleaned)
+
+	if strings.HasPrefix(lowerQ, "what's the best") {
+		return fmt.Sprintf("Pro tip: %s", strings.TrimPrefix(cleaned, "What's the best "))
+	}
+	if strings.HasPrefix(lowerQ, "how do you") {
+		return fmt.Sprintf("Here's how to %s effectively", strings.TrimPrefix(lowerQ, "how do you "))
+	}
+	if strings.HasPrefix(lowerQ, "what") {
+		return fmt.Sprintf("Remember: %s matters more than you think in %s",
+			strings.TrimPrefix(cleaned, "What "), topic)
+	}
+
+	return fmt.Sprintf("Pro tip for %s: Focus on %s", topic, strings.ToLower(cleaned))
+}
+
+// transformToStatement converts a question to an opinion/statement format
+func (s *Service) transformToStatement(question, topic string) string {
+	cleaned := strings.TrimSuffix(question, "?")
+	cleaned = strings.TrimSpace(cleaned)
+
+	lowerQ := strings.ToLower(cleaned)
+
+	if strings.Contains(lowerQ, "best") || strings.Contains(lowerQ, "favorite") {
+		return fmt.Sprintf("Unpopular opinion: The most overrated thing in %s is [fill in the blank]", topic)
+	}
+	if strings.Contains(lowerQ, "challenge") || strings.Contains(lowerQ, "difficult") {
+		return fmt.Sprintf("The biggest %s mistake I see everywhere: [share yours]", topic)
+	}
+	if strings.Contains(lowerQ, "experience") || strings.Contains(lowerQ, "time") {
+		return fmt.Sprintf("Share your most surprising %s discovery", topic)
+	}
+
+	return fmt.Sprintf("Hot take: %s isn't as important as everyone thinks in %s",
+		strings.Split(lowerQ, " ")[0], topic)
 }
 
 func (s *Service) generateCompletion(ctx context.Context, prompt string) (string, error) {

--- a/apps/ai-engine/internal/platform/llm/ollama.go
+++ b/apps/ai-engine/internal/platform/llm/ollama.go
@@ -42,7 +42,7 @@ func NewOllamaClient(config OllamaConfig) *OllamaClient {
 		config.CompletionModel = "llama3:8b"
 	}
 	if config.Timeout == 0 {
-		config.Timeout = 30 * time.Second
+		config.Timeout = 60 * time.Second
 	}
 
 	return &OllamaClient{

--- a/apps/ai-engine/public/index.html
+++ b/apps/ai-engine/public/index.html
@@ -11,7 +11,14 @@
     <div class="container">
         <!-- Header with Status Bar -->
         <header class="header">
-            <h1>🤖 AI Engine Control Panel</h1>
+            <div class="header-top">
+                <h1>🤖 AI Engine Control Panel</h1>
+                <div class="theme-toggle">
+                    <button id="theme-toggle-btn" onclick="toggleTheme()" title="Toggle Dark/Light Theme">
+                        <span id="theme-icon">🌙</span>
+                    </button>
+                </div>
+            </div>
             <div class="status-bar">
                 <span id="embedding-status">Embedding: <span id="embedding-provider">Loading...</span></span>
                 <span id="completion-status">Completion: <span id="completion-provider">Loading...</span></span>
@@ -184,6 +191,31 @@
                 </div>
                 <button id="generate-btn" onclick="handleGenerate()">Generate Ideas</button>
                 <div id="generate-status" class="status-message"></div>
+            </div>
+
+            <div class="section">
+                <h2>📊 Concurrent Request Status</h2>
+                <div class="input-group">
+                    <button id="status-btn" onclick="loadConcurrentStatus()">Refresh Status</button>
+                </div>
+                <div id="concurrent-status-display" class="status-box">
+                    <div class="status-item">
+                        <span class="status-label">Max Concurrent:</span>
+                        <span id="max-concurrent">-</span>
+                    </div>
+                    <div class="status-item">
+                        <span class="status-label">Active Requests:</span>
+                        <span id="active-requests">-</span>
+                    </div>
+                    <div class="status-item">
+                        <span class="status-label">Available Slots:</span>
+                        <span id="available-slots">-</span>
+                    </div>
+                    <div class="status-item">
+                        <span class="status-label">Can Accept Request:</span>
+                        <span id="can-accept-request">-</span>
+                    </div>
+                </div>
             </div>
 
             <div class="section">

--- a/apps/ai-engine/public/style.css
+++ b/apps/ai-engine/public/style.css
@@ -368,7 +368,186 @@ button:disabled {
     color: #2196F3;
 }
 
-/* Responsive Design */
+/* Conversation Starters Display */
+.starters-header {
+    background: linear-gradient(135deg, #4CAF50 0%, #45a049 100%);
+    color: white;
+    padding: 15px 20px;
+    border-radius: 8px 8px 0 0;
+    margin-bottom: 0;
+}
+
+.starters-header h4 {
+    font-size: 1.3rem;
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.generation-metadata {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    opacity: 0.9;
+}
+
+.generation-metadata span {
+    background: rgba(255, 255, 255, 0.2);
+    padding: 4px 8px;
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+}
+
+.starters-list {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-top: none;
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.starter-item {
+    display: flex;
+    align-items: flex-start;
+    padding: 15px 20px;
+    border-bottom: 1px solid #f0f0f0;
+    gap: 15px;
+    transition: background-color 0.2s ease;
+}
+
+.starter-item:hover {
+    background-color: #f8f9fa;
+}
+
+.starter-item:last-child {
+    border-bottom: none;
+}
+
+.starter-number {
+    background: #667eea;
+    color: white;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    font-weight: bold;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+.starter-content {
+    flex: 1;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #333;
+    cursor: pointer;
+    padding: 5px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+
+.starter-content:hover {
+    background-color: #f0f7ff;
+}
+
+.starter-actions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+    align-items: flex-start;
+    margin-top: 2px;
+}
+
+.copy-btn, .share-btn {
+    background: #f8f9fa;
+    border: 1px solid #e0e0e0;
+    color: #666;
+    padding: 6px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.copy-btn:hover {
+    background: #e3f2fd;
+    color: #1976d2;
+    border-color: #1976d2;
+}
+
+.share-btn:hover {
+    background: #f3e5f5;
+    color: #7b1fa2;
+    border-color: #7b1fa2;
+}
+
+.starters-footer {
+    background: #f8f9fa;
+    border: 1px solid #e0e0e0;
+    border-top: none;
+    padding: 15px 20px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    border-radius: 0 0 8px 8px;
+}
+
+.copy-all-btn, .regenerate-btn {
+    background: #667eea;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+}
+
+.copy-all-btn:hover {
+    background: #5a67d8;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(102, 126, 234, 0.3);
+}
+
+.regenerate-btn {
+    background: #4CAF50;
+}
+
+.regenerate-btn:hover {
+    background: #45a049;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(76, 175, 80, 0.3);
+}
+
+/* Responsive Design for Starters */
+@media (max-width: 768px) {
+    .generation-metadata {
+        flex-direction: column;
+        gap: 8px;
+    }
+    
+    .starter-item {
+        flex-direction: column;
+        gap: 10px;
+    }
+    
+    .starter-actions {
+        align-self: flex-end;
+    }
+    
+    .starters-footer {
+        flex-direction: column;
+    }
+    
+    .copy-all-btn, .regenerate-btn {
+        width: 100%;
+    }
+}
 @media (max-width: 768px) {
     .container {
         padding: 10px;
@@ -571,4 +750,358 @@ button:disabled {
     white-space: pre-wrap;
     max-height: 100px;
     overflow-y: auto;
+}
+
+/* Theme Toggle Styles */
+.header-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+}
+
+.theme-toggle {
+    display: flex;
+    align-items: center;
+}
+
+#theme-toggle-btn {
+    background: rgba(255, 255, 255, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    color: white;
+    padding: 10px 15px;
+    border-radius: 50px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+    min-width: 50px;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#theme-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+    border-color: rgba(255, 255, 255, 0.5);
+    transform: scale(1.05);
+}
+
+#theme-toggle-btn:active {
+    transform: scale(0.95);
+}
+
+/* Dark Theme Styles - Minimalist & Beautiful */
+.dark-theme {
+    background: #0f0f0f;
+    color: #d1d5db;
+    min-height: 100vh;
+}
+
+.dark-theme .header {
+    background: #1a1a1a;
+    box-shadow: 0 2px 20px rgba(0, 0, 0, 0.5);
+    border: 1px solid #333333;
+}
+
+.dark-theme .nav-tabs {
+    background: #1a1a1a;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+    border: 1px solid #333333;
+}
+
+.dark-theme .tab-button {
+    background: transparent;
+    color: #888888;
+    transition: all 0.2s ease;
+}
+
+.dark-theme .tab-button:hover {
+    background: #2a2a2a;
+    color: #e5e5e5;
+}
+
+.dark-theme .tab-button.active {
+    background: #2a2a2a;
+    color: #ffffff;
+    border-bottom-color: #ffffff;
+}
+
+.dark-theme .section {
+    background: #1a1a1a;
+    border: 1px solid #333333;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
+}
+
+.dark-theme .section:hover {
+    border-color: #444444;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.dark-theme .section h2 {
+    color: #f3f4f6;
+    font-weight: 500;
+}
+
+.dark-theme .input-group label {
+    color: #e5e7eb;
+    font-weight: 500;
+}
+
+.dark-theme input[type="text"],
+.dark-theme textarea {
+    background: #1a1a1a;
+    border: 1px solid #404040;
+    color: #f3f4f6;
+    padding: 12px 16px;
+    transition: all 0.2s ease;
+}
+
+.dark-theme input[type="text"]:focus,
+.dark-theme textarea:focus {
+    border-color: #6b7280;
+    box-shadow: 0 0 0 2px rgba(107, 114, 128, 0.2);
+    background: #1f1f1f;
+}
+
+.dark-theme input[type="text"]::placeholder,
+.dark-theme textarea::placeholder {
+    color: #9ca3af;
+}
+
+.dark-theme button {
+    background: #374151;
+    color: #f9fafb;
+    border: 1px solid #4b5563;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    transition: all 0.2s ease;
+}
+
+.dark-theme button:hover {
+    background: #4b5563;
+    border-color: #6b7280;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+.dark-theme button:active {
+    background: #1f2937;
+}
+
+.dark-theme button:disabled {
+    background: #1f2937;
+    color: #6b7280;
+    border-color: #374151;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.dark-theme .quick-content button {
+    background: #1f2937;
+    color: #d1d5db;
+    border: 1px solid #374151;
+    transition: all 0.2s ease;
+}
+
+.dark-theme .quick-content button:hover {
+    background: #374151;
+    border-color: #4b5563;
+    color: #f9fafb;
+}
+
+.dark-theme .answer-box {
+    background: #1f2937;
+    border: 1px solid #374151;
+    color: #f3f4f6;
+    padding: 20px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.dark-theme .sources-box {
+    background: #1f2937;
+    border: 1px solid #374151;
+    padding: 20px;
+}
+
+.dark-theme .source-item {
+    background: #111827;
+    border: 1px solid #374151;
+    padding: 16px;
+    margin-bottom: 12px;
+    transition: all 0.2s ease;
+}
+
+.dark-theme .source-item:hover {
+    background: #1f2937;
+    border-color: #4b5563;
+}
+
+.dark-theme .source-title {
+    color: #f9fafb;
+    font-weight: 500;
+}
+
+.dark-theme .source-text {
+    color: #d1d5db;
+    background: #111827;
+    padding: 12px;
+    margin-top: 8px;
+    border-radius: 4px;
+}
+
+.dark-theme .starters-box {
+    background: #1a1a1a;
+    border: 1px solid #333333;
+    padding: 20px;
+}
+
+.dark-theme .starter-item {
+    background: #0a0a0a;
+    border: 1px solid #333333;
+    color: #e5e5e5;
+    padding: 16px;
+    margin-bottom: 12px;
+    transition: all 0.2s ease;
+}
+
+.dark-theme .starter-item:hover {
+    background: #111111;
+    border-color: #444444;
+}
+
+.dark-theme .status-log {
+    background: #1a1a1a;
+    border: 1px solid #333333;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.dark-theme .status-log h3 {
+    color: #ffffff;
+    font-weight: 300;
+}
+
+.dark-theme .log-content {
+    background: #0a0a0a;
+    border: 1px solid #333333;
+    color: #cccccc;
+    padding: 16px;
+}
+
+.dark-theme .log-entry {
+    border-bottom: 1px solid #333333;
+    padding: 8px 0;
+    transition: all 0.2s ease;
+}
+
+.dark-theme .log-entry:hover {
+    background: #111111;
+}
+
+.dark-theme .log-entry:last-child {
+    border-bottom: none;
+}
+
+.dark-theme .log-timestamp {
+    color: #666666;
+}
+
+.dark-theme .log-message {
+    color: #e5e5e5;
+}
+
+/* Flow Diagram Dark Theme */
+.dark-theme .flow-diagram {
+    background: #1a1a1a;
+    border: 1px solid #333333;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.dark-theme .flow-title {
+    color: #ffffff;
+    font-weight: 300;
+}
+
+.dark-theme .flow-step {
+    background: #0a0a0a;
+    color: #e5e5e5;
+    border: 1px solid #333333;
+    padding: 12px 16px;
+    transition: all 0.2s ease;
+}
+
+.dark-theme .flow-step:hover {
+    background: #111111;
+    border-color: #444444;
+}
+
+.dark-theme .flow-step.active {
+    background: #2a2a2a;
+    border-color: #666666;
+    color: #ffffff;
+}
+
+.dark-theme .flow-step.success {
+    background: #1a2a1a;
+    border-color: #2a4a2a;
+    color: #aaffaa;
+}
+
+.dark-theme .flow-step.error {
+    background: #2a1a1a;
+    border-color: #4a2a2a;
+    color: #ffaaaa;
+}
+
+.dark-theme .flow-arrow {
+    color: #666666;
+}
+
+/* Concurrent Status Styles */
+.status-box {
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    padding: 20px;
+    margin-top: 10px;
+}
+
+.dark-theme .status-box {
+    background: #1a1a1a;
+    border: 1px solid #333333;
+    padding: 20px;
+}
+
+.status-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid #e9ecef;
+}
+
+.dark-theme .status-item {
+    border-bottom: 1px solid #333333;
+}
+
+.status-item:last-child {
+    border-bottom: none;
+}
+
+.status-label {
+    font-weight: 500;
+    color: #495057;
+}
+
+.dark-theme .status-label {
+    color: #cccccc;
+}
+
+.status-item span:last-child {
+    font-weight: 600;
+    color: #212529;
+}
+
+.dark-theme .status-item span:last-child {
+    color: #e5e5e5;
 }


### PR DESCRIPTION
 This PR introduces the first user-facing product feature built on top of the v1.0 AI Engine: the **Community Ignition Toolkit**.

 ### Problem Solved

 This feature directly addresses the "empty room" problem for new communities by providing administrators with AI-powered tools to spark engagement.

 ### Implementation Details

 -   **New `generator` Service:** A new, specialized service (`internal/generator`) has been created for non-RAG, generative tasks.
 -   **New API Endpoint:** A `POST /api/v1/generate/conversation-starters` endpoint has been added.
 -   **Architectural Reuse:** This new service successfully reuses the existing, provider-agnostic `CompletionClient`, proving the flexibility of the core architecture. It can be powered by Ollama, Groq, or OpenAI without any changes to the generator logic.

 ### How to Test

 1.  Ensure the AI Engine is running.
 2.  Send a POST request to the new endpoint:

 ```bash
 curl -X POST http://localhost:8000/api/v1/generate/conversation-starters \
   -H "Content-Type: application/json" \
   -d '{"community_topic": "Go Developers", "style": "engaging and thought-provoking"}'
 ```

 The API should return a JSON array of three high-quality conversation starters.
